### PR TITLE
style(scripts): add brace style eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,11 @@ module.exports = {
     'object-curly-spacing': ['error', 'always'],
     'arrow-parens': ['error', 'as-needed'],
 
+    // note you must disable the base rule as it can report incorrect errors
+    // use '@typescript-eslint/brace-style': ['error', '1tbs']
+    'brace-style': 'off',
+    curly: ['error', 'all'],
+
     // ts
     '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
@@ -51,6 +56,7 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-empty-function': 'off',
+    '@typescript-eslint/brace-style': ['error', '1tbs'],
 
     // prettier
     'prettier/prettier': 'error',

--- a/packages/cdk/utils/vNode.ts
+++ b/packages/cdk/utils/vNode.ts
@@ -11,7 +11,9 @@ export const isComment = (node: VNodeChild): boolean => (node as VNode).type ===
 export const isTemplate = (node: VNodeChild): boolean => (node as VNode).type === TEMPLATE
 
 function getChildren(node: VNode, depth: number): VNode | undefined {
-  if (isComment(node)) return
+  if (isComment(node)) {
+    return
+  }
   if (isFragment(node) || isTemplate(node)) {
     return depth > 0 ? getFirstValidNode(node.children as VNodeChild, depth - 1) : undefined
   }
@@ -24,7 +26,9 @@ function getChildren(node: VNode, depth: number): VNode | undefined {
  * @param maxDepth depth to be searched, default is 3
  */
 export function getFirstValidNode(nodes: VNodeChild, maxDepth = 3): VNode | undefined {
-  if (isNil(nodes)) return
+  if (isNil(nodes)) {
+    return
+  }
   if (Array.isArray(nodes) && nodes.length > 0) {
     return getChildren(nodes[0] as VNode, maxDepth)
   }
@@ -47,7 +51,9 @@ export function isValidElementNode(node: VNodeChild): boolean {
  */
 export function getSlotNodes(slots: Slots, key = 'default', ...options: unknown[]): VNode[] {
   const slot = slots[key]
-  if (!slot) return []
+  if (!slot) {
+    return []
+  }
 
   let vNodes = slot(...options)
   if (vNodes.length === 1 && isFragment(vNodes[0])) {

--- a/packages/components/badge/src/Badge.vue
+++ b/packages/components/badge/src/Badge.vue
@@ -56,7 +56,9 @@ const useCountValue = (
 ) => {
   return computed(() => {
     if (!hasCountSlot.value && !dot.value) {
-      if (!showZero.value && +props.count === 0) return false
+      if (!showZero.value && +props.count === 0) {
+        return false
+      }
       if (isNumeric(props.count) && isNumeric(overflowCount.value)) {
         return props.count > overflowCount.value ? `${overflowCount.value}+` : `${props.count}`
       }

--- a/packages/components/space/src/Space.vue
+++ b/packages/components/space/src/Space.vue
@@ -71,19 +71,25 @@ function useSpaceList(
       }
       spaceList = children.map((child, index) => {
         const current: SpaceItem = { node: child, id: index }
-        if (split) return current
-        else if (typeof size[index] === 'number') {
+        if (split) {
+          return current
+        } else if (typeof size[index] === 'number') {
           current.style = { marginRight: `${size[index]}px` }
-        } else current.className = `ix-space-item-${size[index]}`
+        } else {
+          current.className = `ix-space-item-${size[index]}`
+        }
         return current
       })
     } else {
       spaceList = children.map((child, index) => {
         const current: SpaceItem = { node: child, id: index }
-        if (split) return current
-        else if (typeof size === 'number') {
+        if (split) {
+          return current
+        } else if (typeof size === 'number') {
           current.style = { marginRight: `${size}px` }
-        } else current.className = `ix-space-item-${size}`
+        } else {
+          current.className = `ix-space-item-${size}`
+        }
         return current
       })
     }


### PR DESCRIPTION
fix #122

## content
add brace eslint rules:
`'@typescript-eslint/brace-style': ['error', '1tbs']`
`curly: ['error', 'all']`

More content can be found on  [brace-style](https://eslint.org/docs/rules/brace-style#options) and [curly](https://eslint.org/docs/rules/curly#require-following-curly-brace-conventions-curly)

Example:
```javascript
// good

function foo() {
  return true;
}

if (foo) {
  bar();
}

if (foo) {
  bar();
} else {
  baz();
}

try {
  somethingRisky();
} catch(e) {
  handleError();
}

if (foo) {
    foo++;
}

while (bar) {
    baz();
}

if (foo) {
    baz();
} else {
    qux();
}
```




## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IduxFE/components/blob/main/docs/contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Component style update
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

## Other information
