### PR TITLE
feat(cdk:utils): add useEmitter function

### DIFF
--- a/packages/components/core/utils/emitter.ts
+++ b/packages/components/core/utils/emitter.ts
@@ -1,0 +1,113 @@
+// from Element: https://github.com/hug-sun/element3/blob/master/packages/element3/src/use/emitter.js
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getCurrentInstance, onUnmounted, ComponentInternalInstance } from 'vue'
+import mitt, { EventType, Handler } from 'mitt'
+
+const DISPATCH = 'dispatch'
+const BROADCAST = 'broadcast'
+
+const wrapper: unique symbol = Symbol('wrapper')
+
+const emitter = mitt()
+
+type Event = { value: any; type: 'dispatch' | 'broadcast'; emitComponentInstance: ComponentInternalInstance }
+
+interface HandleWrapper {
+  (e?: Event): void
+}
+
+interface EmitterHandler extends Handler {
+  [wrapper]?: HandleWrapper
+}
+
+interface Emitter {
+  on(type: EventType, handler: EmitterHandler): void
+
+  once(type: EventType, handler: EmitterHandler): void
+
+  broadcast(type: EventType, event?: any): void
+
+  dispatch(type: EventType, event?: any): void
+
+  off(type: EventType, handler: EmitterHandler): void
+}
+
+/**
+ * check componentChild is componentParent child components
+ * @param {*} componentChild
+ * @param {*} componentParent
+ */
+function isChildComponent(componentChild: ComponentInternalInstance, componentParent: ComponentInternalInstance) {
+  const parentUId = componentParent.uid
+  while (componentChild && componentChild?.parent?.uid !== parentUId) {
+    componentChild = componentChild.parent as ComponentInternalInstance
+  }
+
+  return Boolean(componentChild)
+}
+
+export function useEmitter(): Emitter {
+  const currentComponentInstance = getCurrentInstance() as ComponentInternalInstance
+
+  function on(type: EventType, handler: EmitterHandler) {
+    const handleWrapper: HandleWrapper = e => {
+      const { value, type, emitComponentInstance } = e as Event
+      if (type === BROADCAST) {
+        if (isChildComponent(currentComponentInstance, emitComponentInstance)) {
+          handler && handler(...value)
+        }
+      } else if (type === DISPATCH) {
+        if (isChildComponent(emitComponentInstance, currentComponentInstance)) {
+          handler && handler(...value)
+        }
+      } else {
+        handler && handler(...value)
+      }
+    }
+
+    // Save the real handler because the need to call off
+    handler[wrapper] = handleWrapper
+    emitter.on(type, handleWrapper)
+
+    // Auto off handler when component unmounted
+    onUnmounted(() => {
+      off(type, handler)
+    })
+  }
+
+  function off(type: EventType, handler: EmitterHandler) {
+    emitter.off(type, handler[wrapper] as EmitterHandler)
+  }
+
+  function once(type: EventType, handler: EmitterHandler) {
+    const handleOn = (...args: any[]) => {
+      handler && handler(...args)
+      off(type, handleOn)
+    }
+    on(type, handleOn)
+  }
+
+  function broadcast(type: EventType, ...args: any[]) {
+    emitter.emit(type, {
+      type: BROADCAST,
+      emitComponentInstance: currentComponentInstance,
+      value: args,
+    })
+  }
+
+  function dispatch(type: EventType, ...args: any[]) {
+    emitter.emit(type, {
+      type: DISPATCH,
+      emitComponentInstance: currentComponentInstance,
+      value: args,
+    })
+  }
+
+  return {
+    on,
+    off,
+    once,
+    broadcast,
+    dispatch,
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IduxFE/components/blob/main/docs/contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
移植Element组件通信事件机制 https://github.com/hug-sun/element3/blob/master/packages/element3/src/use/emitter.js
原有功能：
- 组件通过on/once监听来自于其父/子组件的自定义事件
- 子组件触发父组件的监听事件使用dispatch/父组件触发子组件的监听事件使用broadcast
- 支持off对事件进行解绑

扩展：
- 改为ts实现
- 组件在监听事件后（on/once），自动在unMounted中进行解绑，无须手动；（使用匿名函数形式书写的监听回调函数也可以被自动解绑）




## Other information

@danranVm  @coolyuantao 